### PR TITLE
update_models

### DIFF
--- a/app/models/item_condition.rb
+++ b/app/models/item_condition.rb
@@ -1,4 +1,4 @@
-class Item_condition < ActiveHash::Base
+class ItemCondition < ActiveHash::Base
   self.data = [ 
     {id: 1, name: '新品、未使用'}, 
     {id: 2, name: '未使用に近い'}, 

--- a/app/models/postage_payer.rb
+++ b/app/models/postage_payer.rb
@@ -1,4 +1,4 @@
-class Postage_payer < ActiveHash::Base
+class PostagePayer < ActiveHash::Base
   self.data = [ 
     {id: 1, name: '出品者負担'}, 
     {id: 2, name: '購入者負担'}

--- a/app/models/preparation_day.rb
+++ b/app/models/preparation_day.rb
@@ -1,4 +1,4 @@
-class Preparation_day < ActiveHash::Base
+class PreparationDay < ActiveHash::Base
   self.data = [ 
   {id: 1, name: '1〜2日で発送'}, 
   {id: 2, name: '2〜3日で発送'}, 


### PR DESCRIPTION
# What
Modelsのactive_hashを使う際、クラス名の記述をスネークケースからキャメルケースに変更。

# Why
以前のバージョンでは、active_hashを使用する際のクラス名をスネークケースで記述していた。そのため、正常に値を取れていなかったため、クラス名を規約にしたがってキャメルケースで記述した。