### PR TITLE
Create category selects

### DIFF
--- a/app/assets/stylesheets/api/categories.scss
+++ b/app/assets/stylesheets/api/categories.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the api/categories controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,0 +1,6 @@
+class Api::CategoriesController < ApplicationController
+  def index
+    category = Category.find(params[:category_id])
+    @categories = category.children
+  end
+end

--- a/app/helpers/api/categories_helper.rb
+++ b/app/helpers/api/categories_helper.rb
@@ -1,0 +1,2 @@
+module Api::CategoriesHelper
+end

--- a/app/javascript/category_select.js
+++ b/app/javascript/category_select.js
@@ -1,0 +1,42 @@
+document.addEventListener('turbolinks:load', function () {
+  if (!$('.select-category')[0]) return false; //カテゴリのフォームが無いなら以降実行しない。
+
+    function buildCategoryForm(categories) { // 子孫カテゴリのフォームを組み立てる
+      let options = "";
+      categories.forEach(function (category) { // カテゴリを一つずつ渡してoptionタグを一つずつ組み立てていく。
+      options += `
+                  <option value="${category.id}">${category.name}</option><br>
+                 `;
+    });
+
+      const html = `
+      <select class="select-category" id="parent-category" name="item[category_id]">
+                    <option value="">選択してください</option>
+                    ${options}
+                  </select>
+                   `;
+      return html;
+    }
+
+    $(".sell-collection_select").on("change", ".select-category", function () { 
+      const category_id = $(this).val();
+
+    $.ajax({
+      url: "/api/categories", 
+      type: "GET",
+      data: {
+        category_id: category_id
+      },
+      dataType: 'json',
+    }).done(function (categories) {
+      console.log("success")
+      console.log(categories)
+      const html = buildCategoryForm(categories);
+      console.log(html);
+      $(".select-category:last").after(html);
+    })
+    .fail(function () {
+      alert('error');
+    })
+  });
+});

--- a/app/javascript/category_select.js
+++ b/app/javascript/category_select.js
@@ -1,42 +1,67 @@
 document.addEventListener('turbolinks:load', function () {
-  if (!$('.select-category')[0]) return false; //カテゴリのフォームが無いなら以降実行しない。
+  if (!$('.select-category')[0]) return false; 
 
-    function buildCategoryForm(categories) { // 子孫カテゴリのフォームを組み立てる
+    function buildCategoryForm(categories) { 
       let options = "";
-      categories.forEach(function (category) { // カテゴリを一つずつ渡してoptionタグを一つずつ組み立てていく。
+      if(categories[0].ancestry.indexOf("/", 0) == -1){
+        relation = "child";
+        } else {
+        relation = "grandchild";
+        }
+      categories.forEach(function (category) { 
       options += `
                   <option value="${category.id}">${category.name}</option><br>
                  `;
     });
 
       const html = `
-      <select class="select-category" id="parent-category" name="item[category_id]">
-                    <option value="">選択してください</option>
+                  <br class=“${relation}“>
+                  <select required=“required” class="select-category ${relation}" id="parent-category" name="item[category_id]">
+                    <option value="${relation}">選択してください</option>
                     ${options}
                   </select>
                    `;
       return html;
     }
 
+    function existForm(categories) {
+      if(categories[0].ancestry.indexOf("/", 0) == -1){
+        $('.child').remove();
+        $('.grandchild').remove();
+      } else {
+        $('.grandchild').remove();
+      }
+    }
+    function selectNoValue(categories) {
+      if(categories.initial == "parent"){
+        $('.child').remove();
+        $('.grandchild').remove();
+      } else if(categories.initial == "child"){
+        $('.grandchild').remove();
+      }
+    }
+
     $(".sell-collection_select").on("change", ".select-category", function () { 
       const category_id = $(this).val();
 
-    $.ajax({
-      url: "/api/categories", 
-      type: "GET",
-      data: {
-        category_id: category_id
-      },
-      dataType: 'json',
-    }).done(function (categories) {
-      console.log("success")
-      console.log(categories)
-      const html = buildCategoryForm(categories);
-      console.log(html);
-      $(".select-category:last").after(html);
-    })
-    .fail(function () {
-      alert('error');
-    })
+      $.ajax({
+        url: "/api/categories", 
+        type: "GET",
+        data: {
+          category_id: category_id
+        },
+        dataType: 'json',
+        }).done(function (categories) {
+          console.log(categories.array)
+          if(categories.array.length != 0){
+            existForm(categories.array);
+            const html = buildCategoryForm(categories.array);
+            $(".select-category:last").after(html);
+          }
+            selectNoValue(categories)
+        })
+        .fail(function () {
+          alert('error');
+        })
   });
 });

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ require("@rails/activestorage").start()
 require("channels")
 require("card")
 require("item_images")
+require("category_select")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/views/api/categories/index.json.jbuilder
+++ b/app/views/api/categories/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @categories, :id, :name

--- a/app/views/api/categories/index.json.jbuilder
+++ b/app/views/api/categories/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @categories, :id, :name
+json.array @categories, :id, :name, :ancestry

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -50,7 +50,6 @@
             .sell-collection_select
               = f.label :category_id, {class: 'sell-collection_select__label'} do
                 = f.collection_select :category_id, Category.roots, :id, :name, {prompt: "選択して下さい"},class: "select-category", id: "parent-category"
-                -# = f.collection_select :category_id, Category.roots, :id, :name, {prompt: "選択して下さい"},{ class: 'sell-collection_select__input', id: 'category-select', required: "required"}
                 %i.fas.fa-chevron-down
 
             .sell-title

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -49,7 +49,8 @@
                   必須
             .sell-collection_select
               = f.label :category_id, {class: 'sell-collection_select__label'} do
-                = f.collection_select :category_id, Category.roots, :id, :name, {prompt: "選択して下さい"},{ class: 'sell-collection_select__input', id: 'category-select', required: "required"}
+                = f.collection_select :category_id, Category.roots, :id, :name, {prompt: "選択して下さい"},class: "select-category", id: "parent-category"
+                -# = f.collection_select :category_id, Category.roots, :id, :name, {prompt: "選択して下さい"},{ class: 'sell-collection_select__input', id: 'category-select', required: "required"}
                 %i.fas.fa-chevron-down
 
             .sell-title

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
 
+  namespace :api do
+    resources :categories, only: :index, defaults: { format: 'json' }
+  end
+
   resources :items, only: [:index, :show, :new, :create] do
     member do
      get 'buy'

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -9,3 +9,4 @@ environment.plugins.prepend('Provide',
 )
 
 module.exports = environment
+

--- a/test/controllers/api/categories_controller_test.rb
+++ b/test/controllers/api/categories_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Api::CategoriesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
商品出品時におけるカテゴリ選択で、ancestryを使用した階層選択ができるように実装
現在の出品機能では親カテゴリの選択しかできなかったため、子カテゴリ、孫カテゴリを選択できるようにし、それに対応したcategory_idをDBに保存されるように修正を行った。

# Why
商品出品時に、より詳細なカテゴリを選択できるよう実装を行うことで、検索レベルの精度をあげることが目的である。